### PR TITLE
Enable dynamic volume filtering and pass volatility settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,10 @@ function App() {
     data: portfolio, 
     loading, 
     error 
-  } = useApi<PortfolioSuggestion>(`/api/portfolio?budget=${budget}`, [budget]);
+  } = useApi<PortfolioSuggestion>(
+    `/api/portfolio?budget=${budget}&minVolume=${minVolume}&maxVolatility=${maxVolatility}`,
+    [budget, minVolume, maxVolatility]
+  );
 
   /**
    * Handles manual data refresh by triggering API sync

--- a/src/lib/calculations.ts
+++ b/src/lib/calculations.ts
@@ -282,7 +282,8 @@ export function filterProfitableOpportunities(
   opportunities: FlipOpportunity[],
   minProfit: number = 1000,
   minROI: number = 5,
-  minVolume: number = MIN_VOLUME_THRESHOLDS.DAILY
+  minVolume: number = 0,
+  maxVolatility: number = VOLATILITY_THRESHOLDS.EXTREME
 ): FlipOpportunity[] {
   return opportunities.filter(opp => {
     // Basic profitability filters
@@ -290,13 +291,18 @@ export function filterProfitableOpportunities(
       return false;
     }
 
-    // Volume/liquidity filter
-    if (opp.volume < minVolume) {
+    // Price-adjusted liquidity filter
+    if (!hassufficientVolume(opp.volume, opp.currentHigh)) {
       return false;
     }
 
-    // Extreme volatility filter
-    if (opp.volatility > VOLATILITY_THRESHOLDS.EXTREME) {
+    // Additional user-specified volume filter
+    if (minVolume > 0 && opp.volume < minVolume) {
+      return false;
+    }
+
+    // Volatility filter
+    if (opp.volatility > maxVolatility) {
       return false;
     }
 


### PR DESCRIPTION
## Summary
- create items on-the-fly when syncing prices so new items aren't skipped
- allow API callers to specify `minVolume` and `maxVolatility`
- use price-adjusted volume checks in `filterProfitableOpportunities`
- expose filter parameters through client `useApi` call

## Testing
- `npm run lint` *(fails: Unexpected any, no-var, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685da09bfb8c8331ab9afdcfbf9d3a8e