### PR TITLE
Update BudgetInput max value

### DIFF
--- a/src/components/BudgetInput.tsx
+++ b/src/components/BudgetInput.tsx
@@ -66,7 +66,7 @@ export function BudgetInput({ budget, onBudgetChange, disabled }: BudgetInputPro
           <input
             type="range"
             min={100000}
-            max={1000000000}
+            max={2147483647}
             step={100000}
             value={budget}
             onChange={handleSliderChange}


### PR DESCRIPTION
## Summary
- increase budget slider max to 2.147B

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685da588c92c8331afac78ca05bdde5e