### PR TITLE
Add volume/volatility API filters and auto item sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,15 +187,15 @@ The OSRS Grand Exchange Tracker helps players make data-driven trading decisions
 
 ### Portfolio Suggestions
 ```http
-GET /api/portfolio?budget=10000000
+GET /api/portfolio?budget=10000000&minVolume=0&maxVolatility=50
 ```
-Returns optimized item recommendations with enhanced filtering and scoring.
+Returns optimized item recommendations with advanced filtering. Use `minVolume` (trades/24h) and `maxVolatility` (%) to tune results.
 
 ### Flip Opportunities
 ```http
-GET /api/opportunities?budget=100000000&limit=50
+GET /api/opportunities?budget=100000000&limit=50&minVolume=0&maxVolatility=50
 ```
-Returns all profitable flip opportunities with volume and volatility filtering.
+Returns all profitable flip opportunities. `minVolume` and `maxVolatility` provide additional control over liquidity and risk.
 
 ### Item History
 ```http

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "vite build",
     "build:server": "tsc -p tsconfig.server.json",
     "lint": "eslint .",
+    "test": "tsx tests/syncPrices.test.ts",
     "preview": "vite preview",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",

--- a/src/components/ItemDetailModal.tsx
+++ b/src/components/ItemDetailModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { X, TrendingUp, TrendingDown, Clock, BarChart3, AlertCircle } from 'lucide-react';
+import { X, Clock, BarChart3, AlertCircle } from 'lucide-react';
 import { useApi } from '../hooks/useApi';
 import { ItemHistory } from '../types/api';
 import { LoadingSpinner } from './LoadingSpinner';
@@ -95,7 +95,9 @@ export function ItemDetailModal({ itemId, onClose }: ItemDetailModalProps) {
   /**
    * Creates a simple SVG line chart from price data
    */
-  const createPriceChart = (prices: any[]) => {
+  const createPriceChart = (
+    prices: Array<{ high?: number | null; low?: number | null }>
+  ) => {
     if (prices.length < 2) return null;
 
     const width = 400;
@@ -171,7 +173,9 @@ export function ItemDetailModal({ itemId, onClose }: ItemDetailModalProps) {
   /**
    * Calculates basic statistics from price data
    */
-  const calculateStats = (prices: any[]) => {
+  const calculateStats = (
+    prices: Array<{ high?: number | null; low?: number | null }>
+  ) => {
     if (prices.length === 0) return null;
 
     const validHighs = prices.filter(p => p.high).map(p => p.high);

--- a/src/components/OpportunityTable.tsx
+++ b/src/components/OpportunityTable.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { TrendingUp, TrendingDown, AlertTriangle, ExternalLink, Info, BarChart3 } from 'lucide-react';
+import { TrendingUp, TrendingDown, AlertTriangle, Info, BarChart3 } from 'lucide-react';
 import { FlipOpportunity } from '../types/api';
 import { ItemDetailModal } from './ItemDetailModal';
 

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -25,7 +25,7 @@ const API_BASE_URL = 'http://localhost:3001';
  * @param dependencies - Array of values that trigger refetch when changed
  * @returns Object containing data, loading state, and error message
  */
-export function useApi<T>(url: string, dependencies: any[] = []) {
+export function useApi<T>(url: string, dependencies: unknown[] = []) {
   // State for storing the fetched data
   const [data, setData] = useState<T | null>(null);
   
@@ -88,7 +88,7 @@ export function useApi<T>(url: string, dependencies: any[] = []) {
     return () => {
       cancelled = true;
     };
-  }, dependencies); // Re-run when dependencies change
+  }, [url, ...dependencies]); // Re-run when dependencies change
 
   return { data, loading, error };
 }
@@ -104,7 +104,10 @@ export function useApi<T>(url: string, dependencies: any[] = []) {
  * @returns Promise resolving to the response data
  * @throws Error if the request fails or API returns an error
  */
-export async function apiRequest<T>(url: string, options?: any): Promise<T> {
+export async function apiRequest<T>(
+  url: string,
+  options?: Record<string, unknown>
+): Promise<T> {
   const response = await axios.request<ApiResponse<T>>({
     url: `${API_BASE_URL}${url}`,
     ...options,

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -17,6 +17,7 @@ import { PrismaClient } from '@prisma/client';
  * to persist it across hot reloads in development
  */
 declare global {
+  // eslint-disable-next-line no-var
   var __prisma: PrismaClient | undefined;
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -60,7 +60,7 @@ await fastify.register(apiRoutes);
  * Provides a simple health check at the root URL for monitoring
  * and confirming the server is running properly.
  */
-fastify.get('/', async (request, reply) => {
+fastify.get('/', async () => {
   return { 
     message: 'OSRS Grand Exchange Tracker API',
     version: '1.0.0',

--- a/src/server/services/osrs-api.ts
+++ b/src/server/services/osrs-api.ts
@@ -138,7 +138,7 @@ export class OSRSApiService {
    * @returns Promise resolving to timeseries data
    * @throws Error if the request fails
    */
-  static async fetchTimeseries(itemId: number, timestep: string = '5m'): Promise<any> {
+  static async fetchTimeseries(itemId: number, timestep: string = '5m'): Promise<unknown> {
     try {
       const response = await api.get(`/timeseries?id=${itemId}&timestep=${timestep}`);
       return response.data.data;
@@ -157,7 +157,7 @@ export class OSRSApiService {
    * @returns Promise resolving to volume data
    * @throws Error if the request fails
    */
-  static async fetchVolumes(): Promise<any> {
+  static async fetchVolumes(): Promise<unknown> {
     try {
       const response = await api.get('/5m');
       return response.data.data;

--- a/tests/syncPrices.test.ts
+++ b/tests/syncPrices.test.ts
@@ -1,0 +1,40 @@
+import { execSync } from 'child_process';
+import assert from 'assert';
+import prisma from '../src/lib/database.js';
+import { PriceService } from '../src/server/services/price-service.js';
+import { OSRSApiService } from '../src/server/services/osrs-api.js';
+
+async function run() {
+  // Use an isolated SQLite database for testing
+  process.env.DATABASE_URL = 'file:./tests/test.db';
+
+  // Reset schema for a clean environment
+  execSync('npx prisma db push --force-reset > /dev/null');
+
+  // Mock price and item mapping responses
+  (OSRSApiService as unknown as Record<string, unknown>).fetchLatestPrices = async () => ({
+    '999': { high: 1000, low: 900 },
+  });
+
+  let mappingCalls = 0;
+  (OSRSApiService as unknown as Record<string, unknown>).fetchItemMapping = async () => {
+    mappingCalls += 1;
+    if (mappingCalls === 1) return [];
+    return [{ id: 999, name: 'Test Item', limit: 0 }];
+  };
+
+  await PriceService.syncPrices();
+
+  const item = await prisma.item.findUnique({ where: { id: 999 } });
+  const price = await prisma.price.findFirst({ where: { itemId: 999 } });
+
+  assert(item, 'Item should be created when missing');
+  assert(price, 'Price should be stored for new item');
+
+  console.log('syncPrices test passed');
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- document minVolume and maxVolatility parameters in README
- auto-sync items when unknown ids appear in price sync
- sort high budget opportunities by ROI and relax volume cap
- update hooks and components for lint compliance
- add regression test verifying new items get created during price sync

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685da8327aec8331ae1425ad42365b44