### PR TITLE
Add advanced opportunity controls

### DIFF
--- a/src/components/AdvancedFilters.tsx
+++ b/src/components/AdvancedFilters.tsx
@@ -6,6 +6,10 @@ interface AdvancedFiltersProps {
   onMinVolumeChange: (v: number) => void;
   maxVolatility: number;
   onMaxVolatilityChange: (v: number) => void;
+  showSpikes: boolean;
+  onShowSpikesChange: (v: boolean) => void;
+  showHighRisk: boolean;
+  onShowHighRiskChange: (v: boolean) => void;
   disabled?: boolean;
 }
 
@@ -14,6 +18,10 @@ export function AdvancedFilters({
   onMinVolumeChange,
   maxVolatility,
   onMaxVolatilityChange,
+  showSpikes,
+  onShowSpikesChange,
+  showHighRisk,
+  onShowHighRiskChange,
   disabled,
 }: AdvancedFiltersProps) {
   return (
@@ -48,7 +56,7 @@ export function AdvancedFilters({
           <input
             type="range"
             min={0}
-            max={50}
+            max={500}
             step={1}
             value={maxVolatility}
             onChange={(e) => onMaxVolatilityChange(parseInt(e.target.value))}
@@ -56,6 +64,30 @@ export function AdvancedFilters({
             className="w-full h-2 bg-gray-200 rounded-lg cursor-pointer accent-blue-500"
           />
           <div className="text-sm text-gray-600 mt-1">{maxVolatility}%</div>
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            id="showSpikes"
+            checked={showSpikes}
+            onChange={(e) => onShowSpikesChange(e.target.checked)}
+            disabled={disabled}
+          />
+          <label htmlFor="showSpikes" className="text-sm text-gray-700">
+            Show items with detected price spikes
+          </label>
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            id="showHighRisk"
+            checked={showHighRisk}
+            onChange={(e) => onShowHighRiskChange(e.target.checked)}
+            disabled={disabled}
+          />
+          <label htmlFor="showHighRisk" className="text-sm text-gray-700">
+            Show high-risk items (&gt;25% volatility)
+          </label>
         </div>
       </div>
     </div>

--- a/src/server/routes/api.ts
+++ b/src/server/routes/api.ts
@@ -29,13 +29,15 @@ export async function apiRoutes(fastify: FastifyInstance) {
    * Returns: PortfolioSuggestion object with selected opportunities and metrics
    */
   fastify.get<{
-    Querystring: { budget: string; minVolume?: string; maxVolatility?: string };
+    Querystring: { budget: string; minVolume?: string; maxVolatility?: string; includeSpikes?: string; includeHighRisk?: string };
   }>('/api/portfolio', async (request, reply) => {
     try {
       // Parse and validate budget parameter
       const budget = parseFloat(request.query.budget) || 10000000;
       const minVolume = request.query.minVolume ? parseInt(request.query.minVolume) : 0;
       const maxVolatility = request.query.maxVolatility ? parseFloat(request.query.maxVolatility) : VOLATILITY_THRESHOLDS.EXTREME;
+      const includeSpikes = request.query.includeSpikes === 'true';
+      const includeHighRisk = request.query.includeHighRisk === 'true';
       
       // Validate budget range (must be positive and within int32 limits)
       if (budget <= 0 || budget > 2147483647) {
@@ -50,6 +52,8 @@ export async function apiRoutes(fastify: FastifyInstance) {
       const portfolio = await PriceService.getPortfolioSuggestion(budget, {
         minVolume,
         maxVolatility,
+        includeSpikes,
+        includeHighRisk,
       });
       
       return reply.send({
@@ -85,6 +89,8 @@ export async function apiRoutes(fastify: FastifyInstance) {
       limit?: string;
       minVolume?: string;
       maxVolatility?: string;
+      includeSpikes?: string;
+      includeHighRisk?: string;
     };
   }>('/api/opportunities', async (request, reply) => {
     try {
@@ -93,11 +99,15 @@ export async function apiRoutes(fastify: FastifyInstance) {
       const limit = parseInt(request.query.limit || '50');
       const minVolume = request.query.minVolume ? parseInt(request.query.minVolume) : 0;
       const maxVolatility = request.query.maxVolatility ? parseFloat(request.query.maxVolatility) : VOLATILITY_THRESHOLDS.EXTREME;
+      const includeSpikes = request.query.includeSpikes === 'true';
+      const includeHighRisk = request.query.includeHighRisk === 'true';
       
       // Get all opportunities with enhanced filtering and scoring
       const opportunities = await PriceService.getFlipOpportunities(budget, {
         minVolume,
         maxVolatility,
+        includeSpikes,
+        includeHighRisk,
       });
       const limitedOpportunities = opportunities.slice(0, limit);
       


### PR DESCRIPTION
## Summary
- implement advanced filters for spikes and volatility
- add portfolio/all opportunities toggle with limit selector
- expose filters via new API params and service options
- show API query in dev for easier debugging

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685db77d5e6883318f8a8ddf8ffae900