### PR TITLE
Implement historical price sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "vite build",
     "build:server": "tsc -p tsconfig.server.json",
     "lint": "eslint .",
-    "test": "tsx tests/syncPrices.test.ts",
+    "test": "tsx tests/syncPrices.test.ts && tsx tests/historicalSync.test.ts",
     "preview": "vite preview",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",

--- a/src/server/jobs/price-sync.ts
+++ b/src/server/jobs/price-sync.ts
@@ -71,6 +71,7 @@ export class PriceSyncJob {
       try {
         console.log('Starting scheduled item sync...');
         await PriceService.syncItems();
+        await PriceService.syncHistoricalPrices();
         console.log('Scheduled item sync completed successfully');
       } catch (error) {
         console.error('Scheduled item sync failed:', error);
@@ -97,6 +98,9 @@ export class PriceSyncJob {
       
       // Then sync current prices
       await PriceService.syncPrices();
+
+      // Populate historical data if needed
+      await PriceService.syncHistoricalPrices();
       
       console.log('Initial data sync completed successfully');
     } catch (error) {

--- a/src/server/services/osrs-api.ts
+++ b/src/server/services/osrs-api.ts
@@ -128,6 +128,26 @@ export class OSRSApiService {
   }
 
   /**
+   * Fetches 1-hour historical prices for a specific item
+   *
+   * This endpoint returns hourly average high/low prices which are
+   * useful for bootstrapping the database with recent history.
+   *
+   * @param itemId - The item ID to fetch data for
+   * @returns Promise resolving to array of hourly price records
+   */
+  static async fetch1hHistory(itemId: number): Promise<OSRS1hPriceEntry[]> {
+    try {
+      const response = await api.get(`/1h?id=${itemId}`);
+      const data = response.data?.data?.[itemId] || response.data?.data || [];
+      return Array.isArray(data) ? data : Object.values(data);
+    } catch (error) {
+      console.error(`Failed to fetch 1h history for item ${itemId}:`, error);
+      throw new Error(`Failed to fetch 1h history for item ${itemId}`);
+    }
+  }
+
+  /**
    * Fetches historical price data for a specific item
    * 
    * This endpoint provides time-series data for price analysis and

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -64,6 +64,17 @@ export interface OSRSVolumeData {
 }
 
 /**
+ * Hourly historical price entry returned from the /1h endpoint
+ */
+export interface OSRS1hPriceEntry {
+  timestamp: number;
+  avgHighPrice?: number | null;
+  avgLowPrice?: number | null;
+  highPriceVolume?: number;
+  lowPriceVolume?: number;
+}
+
+/**
  * Flip Opportunity Interface
  * 
  * Represents a calculated trading opportunity with all relevant metrics.

--- a/tests/historicalSync.test.ts
+++ b/tests/historicalSync.test.ts
@@ -1,0 +1,34 @@
+import { execSync } from 'child_process';
+import assert from 'assert';
+import prisma from '../src/lib/database.js';
+import { PriceService } from '../src/server/services/price-service.js';
+import { OSRSApiService } from '../src/server/services/osrs-api.js';
+
+async function run() {
+  process.env.DATABASE_URL = 'file:./tests/test.db';
+  execSync('npx prisma db push --force-reset > /dev/null');
+
+  (OSRSApiService as unknown as Record<string, unknown>).fetchItemMapping = async () => [
+    { id: 100, name: 'Test Item', limit: 0 },
+  ];
+  (OSRSApiService as unknown as Record<string, unknown>).fetch24hVolumes = async () => ({
+    '100': { highPriceVolume: 50, lowPriceVolume: 50 },
+  });
+  (OSRSApiService as unknown as Record<string, unknown>).fetch1hHistory = async () => [
+    { timestamp: 1000, avgHighPrice: 2000, avgLowPrice: 1900, highPriceVolume: 10, lowPriceVolume: 5 },
+    { timestamp: 2000, avgHighPrice: 2100, avgLowPrice: 1950, highPriceVolume: 8, lowPriceVolume: 7 },
+  ];
+
+  await PriceService.syncItems();
+  await PriceService.syncHistoricalPrices();
+
+  const history = await prisma.priceHistory.findMany({ where: { itemId: 100 } });
+  assert(history.length === 2, 'Historical prices should be inserted');
+
+  console.log('historical sync test passed');
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add OSRS API helper for hourly history
- batch create price history during startup
- trigger history sync on item sync schedule
- test the historical price sync logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dbfd867688331b86882350df1a721