### PR TITLE
Add VITE_API_BASE_URL support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for OSRS GE Tracker
+
+# Base URL for API requests used by the frontend
+VITE_API_BASE_URL=http://localhost:3001
+

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ The OSRS Grand Exchange Tracker helps players make data-driven trading decisions
    cp .env.example .env
    # Edit .env with your configuration
    ```
+   The `VITE_API_BASE_URL` variable controls where the frontend sends API
+   requests. Set it to your backend URL (e.g. `http://localhost:3001`) or leave
+   it empty to use relative paths during local development.
 
 5. **Start the application**
    ```bash

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -4,9 +4,9 @@ import { ApiResponse } from '../types/api';
 
 /**
  * Base URL for API requests
- * Points to the local development server
- */
-const API_BASE_URL = 'http://localhost:3001';
+ * Configurable via the VITE_API_BASE_URL environment variable
+*/
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
 
 /**
  * Custom React Hook for API Data Fetching


### PR DESCRIPTION
## Summary
- make API base URL configurable via `VITE_API_BASE_URL`
- document the new environment variable in README
- provide `.env.example` with default value

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685dc673f7a0833182320149a1eb1340