### PR TITLE
Add ROI sanity check

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "vite build",
     "build:server": "tsc -p tsconfig.server.json",
     "lint": "eslint .",
-    "test": "tsx tests/syncPrices.test.ts && tsx tests/historicalSync.test.ts",
+    "test": "tsx tests/syncPrices.test.ts && tsx tests/historicalSync.test.ts && tsx tests/profitableOpportunities.test.ts",
     "preview": "vite preview",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",

--- a/src/lib/calculations.ts
+++ b/src/lib/calculations.ts
@@ -49,6 +49,12 @@ export const PRICE_SPIKE_THRESHOLDS = {
 };
 
 /**
+ * Maximum margin percentage allowed for opportunities
+ * Used to filter out data anomalies and unrealistic ROI
+ */
+export const MAX_MARGIN_PERCENT = 1000;
+
+/**
  * Calculates the raw margin between high and low prices
  * 
  * @param high - Sell price (high price)
@@ -288,6 +294,11 @@ export function filterProfitableOpportunities(
   return opportunities.filter(opp => {
     // Basic profitability filters
     if (opp.profitAfterTax < minProfit || opp.roi < minROI) {
+      return false;
+    }
+
+    // Skip unrealistic opportunities with extremely high margin percentages
+    if (opp.marginPercent > MAX_MARGIN_PERCENT) {
       return false;
     }
 

--- a/tests/profitableOpportunities.test.ts
+++ b/tests/profitableOpportunities.test.ts
@@ -1,0 +1,37 @@
+import assert from 'assert';
+import { filterProfitableOpportunities, MAX_MARGIN_PERCENT } from '../src/lib/calculations.js';
+import type { FlipOpportunity } from '../src/types/api.js';
+
+async function run() {
+  const base: FlipOpportunity = {
+    id: 1,
+    name: 'Test',
+    currentHigh: 100,
+    currentLow: 90,
+    avgPrice: 95,
+    margin: 10,
+    marginPercent: 10,
+    roi: 10,
+    quantity: 1,
+    totalCost: 90,
+    totalProfit: 10,
+    profitAfterTax: 2000,
+    buyLimit: 100,
+    volume: 2000,
+    volatility: 5,
+    lastUpdated: new Date(),
+  };
+
+  const valid = { ...base, id: 2, marginPercent: MAX_MARGIN_PERCENT };
+  const invalid = { ...base, id: 3, marginPercent: MAX_MARGIN_PERCENT + 1 };
+
+  const result = filterProfitableOpportunities([valid, invalid]);
+  assert.strictEqual(result.length, 1, 'High margin items should be filtered');
+  assert.strictEqual(result[0].id, 2);
+  console.log('profitable opportunities filter test passed');
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- set `MAX_MARGIN_PERCENT` in `calculations.ts`
- filter out opportunities whose margin exceeds that constant
- test the new behavior
- run all existing tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dc72e1a088331bfdebcb4c96987f0