### PR TITLE
Fix default API base URL

### DIFF
--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -6,7 +6,11 @@ import { ApiResponse } from '../types/api';
  * Base URL for API requests
  * Configurable via the VITE_API_BASE_URL environment variable
 */
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+// Default to the local API server when the environment variable is not set
+// This matches the behaviour documented in the README so the frontend works
+// out-of-the-box during development.
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
 
 /**
  * Custom React Hook for API Data Fetching


### PR DESCRIPTION
## Summary
- default to `http://localhost:3001` when `VITE_API_BASE_URL` isn't set

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ddbd543b483319234470159820124